### PR TITLE
No replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,6 @@ Add a `config/initializers/slave_pools.rb` if you want to change config settings
 
     SlavePools.config.defaults_to_master = true
 
-#### Configure Errors to not replay on master
-
-Some errors you may not want to replay on master, e.g. queries that timeout.
-
-This can be configured by updating the no_replay_on_master with a hash of errors and the corresponding messages that should not be replayed, e.g.:
-
-    SlavePools.config.no_replay_on_master = {
-      'Mysql2::Error' => ['Timeout waiting for a response from the last query', 'other error message that you don't want to replay'],
-      'TimeoutError' => ['some message']
-    }
-
 ## Usage
 
 Toggle to next replica:

--- a/lib/slave_pools/config.rb
+++ b/lib/slave_pools/config.rb
@@ -13,16 +13,10 @@ module SlavePools
     # Defaults are based on Rails version.
     attr_accessor :safe_methods
 
-    # enter a list of errors/messages that shouldn't fall back to master
-    # of the form {'ErrorClass' => ['message regex1', 'message regex 2'], }
-    # Defaults are {'Mysql2::Error' => ['Timeout waiting for a response from the last query']}.
-    attr_accessor :no_replay_on_master
-
     def initialize
       @environment        = 'development'
       @defaults_to_master = false
       @safe_methods       = []
-      @no_replay_on_master = {}
     end
   end
 end

--- a/lib/slave_pools/engine.rb
+++ b/lib/slave_pools/engine.rb
@@ -21,11 +21,6 @@ module SlavePools
         else
           warn "Unsupported ActiveRecord version #{ActiveRecord.version}. Please whitelist the safe methods."
         end
-      if SlavePools.config.no_replay_on_master.blank?
-        SlavePools.config.no_replay_on_master = {
-          'Mysql2::Error' => ['Timeout waiting for a response from the last query']
-        }
-      end
     end
 
     config.after_initialize do

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -143,16 +143,7 @@ describe SlavePools do
     @proxy.should respond_to(:unsafe)
   end
 
-  it 'should rescue an error not flagged as no replay' do
-    SlavePools.config.no_replay_on_master = {'Mysql2::Error' => ['random message']}
-    @default_slave1.should_receive(:select_all).once.and_raise(Mysql2::Error.new('Timeout waiting for a response'))
-    @default_slave2.should_not_receive(:select_all)
-    @master.should_receive(:select_all).and_return(true)
-    lambda { @proxy.select_all(@sql) }.should_not raise_error
-  end
-
-  it 'should re-raise a Error that is flagged as no replay' do
-    SlavePools.config.no_replay_on_master = {'ArgumentError' => ['random message']}
+  it 'should not replay errors on master' do
     @default_slave1.should_receive(:select_all).once.and_raise(ArgumentError.new('random message'))
     @default_slave2.should_not_receive(:select_all)
     @master.should_not_receive(:select_all)


### PR DESCRIPTION
### WHAT

We had previously blacklisted queries not to replay on master. Now we are thinking that it might be better not to replay ANY queries on master. If we think of any queries that need to be replayed, we can create a whitelist (instead of a blacklist).

Do we think there are any queries that should be whitelisted from the beginning?
