### PR TITLE
remove leader lock

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'bundler/setup'
+require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'
 


### PR DESCRIPTION
Historically, the `with_leader{ ... }` block has prevented any attempts at nested `with_pool{ ... }` overrides. If you tried, the block would run but remain on the leader. The goal, I believe, was to prevent mistakes from switching back to a replica without realizing some greater context.

In practice the `with_leader{ ... }` and `with_pool{ ... }` calls don't frequently nest, and when they do, it's reasonable to expect that the programmer intends them that way. So let's allow a leader-by-default strategy by permitting `with_pool{ ... }` to operate within `with_leader{ ... }`.
