### PR TITLE
require host application to decide on reconnect strategy

### DIFF
--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -108,8 +108,6 @@ module ReplicaPools
     rescue => e
       ReplicaPools.log :error, "Error during ##{method}: #{e}"
       log_proxy_state
-
-      current.retrieve_connection.verify! # may reconnect
       raise e
     end
 


### PR DESCRIPTION
the `verify!` command is implemented as `reconnect! unless active?`. its purpose here was to prevent a query timeout from leaving the connection in a bad state. but in current versions of rails it ended up creating another error (NoMethodError: undefined method rollback) because the current transaction has already been auto-closed by the reconnection.

suggested fix is `reconnect: true` in database.yml. this is supported by activerecord and allows exceptions to bubble up to an expected rollback before the next query re-establishes the connection.