### PR TITLE
ensure that initializers are run in order

### DIFF
--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -2,7 +2,10 @@ require 'rails/engine'
 
 module ReplicaPools
   class Engine < Rails::Engine
-    initializer 'replica_pools.defaults' do
+    # the :finisher_hook initializer is what runs :after_initializer
+    # callbacks. we want to guarantee that this configuration happens
+    # before `setup!` no matter what else happens to initializer order.
+    initializer 'replica_pools.defaults', before: :finisher_hook do
       ReplicaPools.config.environment = Rails.env
 
       ReplicaPools.config.safe_methods =


### PR DESCRIPTION
It was possible for another engine to affect the run order by adding an initializer of its own `after: :finisher_hook`, causing `ReplicaPools.setup!` to run while the env was set to `development` and effectively disabling replica pool usage.

I inspected initializer order in a real app to ensure that this doesn't have a similar effect.