### PR TITLE
[Rails 5] Add select_prepared to whitelist, duplicate 4.2 QueryCache behavior

### DIFF
--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -15,11 +15,17 @@ module ReplicaPools
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
             :disconnect!, :reset_runtime, :log, :log_info
           ]
-        elsif [4, 5].include? ActiveRecord::VERSION::MAJOR
+        elsif ActiveRecord::VERSION::MAJOR == 4
           [
             :select_all, :select_one, :select_value, :select_values,
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
             :disconnect!, :reset_runtime, :log
+          ]
+        elsif ActiveRecord::VERSION::MAJOR == 5
+          [
+           :select_all, :select_one, :select_value, :select_values,
+           :select_rows, :select, :select_prepared, :verify!, :raw_connection,
+           :active?, :reconnect!, :disconnect!, :reset_runtime, :log
           ]
         else
           warn "Unsupported ActiveRecord version #{ActiveRecord.version}. Please whitelist the safe methods."

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.1.0.rc1"
+  VERSION = "2.1.0.rc2"
 end

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.1.0.rc2"
+  VERSION = "2.1.0"
 end

--- a/spec/query_cache_spec.rb
+++ b/spec/query_cache_spec.rb
@@ -2,7 +2,6 @@ require 'rack'
 require_relative 'spec_helper'
 
 describe ReplicaPools::QueryCache do
-
   before(:each) do
     @sql = 'SELECT NOW()'
 
@@ -104,5 +103,4 @@ describe ReplicaPools::QueryCache do
       end
     end
   end
-
 end


### PR DESCRIPTION
## what

Part of #17 for supporting Rails 5. 

* Whitelist `select_prepared` for replica connections
* Duplicate the new [`bind_from_relation` functionality](https://github.com/rails/rails/commit/433b19d7e82263fb78c481576ed0f475a62fde06) introduced in 4.2's `select_all`

## Rails 5: done

- [x] go through all of the Rails 4 whitelisted methods and confirm that they still exist with the same parameters.
- [x] ensure we aren't using any methods that may have had params changed (ala `cache_sql`)
- [x] ensure we aren't overriding any new functionality for overridden methods whose internals may have changed (ala `select_all`).

## Rails 5: todo

- [x] 2x check for methods we can add to whitelist as replica-safe.
- [x] validate in real app

cc. @kickstarter/devops @jgubman 