### PR TITLE
Use docker-compose to run tests in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,17 @@
-rvm:
-  - 2.3.3
+sudo: required
+
+language: ruby
+cache: bundler
+
+env:
+  global:
+  - MYSQL_PORT=3306
+
+services:
+  - mysql
+
+before_install:
+  - mysql --verbose --user=root --host=127.0.0.1 --port=3306 mysql < spec/config/bootstrap.sql
+
+script:
+  - bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -162,22 +162,27 @@ Here's one way to accomplish that:
 
 ## Running specs
 
-If you haven't already, install the rspec gem, then set up your database
-with a test database and a read_only user.
+Tests are run against MySQL 5.6 using docker-compose. 🐋
 
-To match spec/config/database.yml, you can run:
+To get set up, first run:
 
-    rake bootstrap
+```bash
+$ docker-compose up
+$ bundle install
+$ bundle exec rake bootstrap
+```
 
-From the plugin directory, run:
+Then you can run tests with:
 
-    rspec spec
+```bash
+$ bundle exec rake spec
+```
 
 ## Authors
 
 Author: Dan Drabik, Lance Ivy
 
-Copyright (c) 2012-2013, Kickstarter
+Copyright (c) 2012-2018, Kickstarter
 
 Released under the MIT license
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,9 @@ task :default => :spec
 
 desc 'Bootstrap MySQL configuration'
 task :bootstrap do
-  system 'mysql -u root mysql < spec/config/bootstrap.sql'
+  puts "executing spec/config/bootstrap.sql\n\n"
+  system('mysql --verbose --user=root --host=127.0.0.1 --port=3309 mysql < spec/config/bootstrap.sql')
 end
 
 desc "Run specs"
-RSpec::Core::RakeTask.new(spec: :bootstrap)
+RSpec::Core::RakeTask.new(:spec)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2.0'
+
+services:
+  mysql:
+    image: mysql:5.6
+    ports:
+      - 127.0.0.1:3309:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"

--- a/replica_pools.gemspec
+++ b/replica_pools.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
 
   s.add_dependency('activerecord', [">= 3.2.12"])
-  s.add_development_dependency('mysql2', ["~> 0.3.11"])
+  s.add_development_dependency('mysql2', ["~> 0.4.4"])
   s.add_development_dependency('rack')
   s.add_development_dependency('rspec')
   s.add_development_dependency('rake')

--- a/spec/config/bootstrap.sql
+++ b/spec/config/bootstrap.sql
@@ -1,3 +1,3 @@
 -- Create MySQL db & user for running specs
 create database IF NOT EXISTS test_db;
-grant select on test_db.* to 'read_only'@'localhost' identified by 'readme';
+grant select on test_db.* to 'read_only' identified by 'readme';

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -1,8 +1,9 @@
 test: &test
   adapter: mysql2
   username: root
-  password:
-  host: localhost
+  password: ''
+  host: 127.0.0.1
+  port: <%= ENV["MYSQL_PORT"] || 3309 %>
   encoding: utf8
   read_timeout: 1
   database: test_db

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,7 @@ end
 require 'active_record'
 spec_dir = File.dirname(__FILE__)
 ActiveRecord::Base.logger = Logger.new(spec_dir + "/debug.log")
-ActiveRecord::Base.configurations = YAML::load(File.open(spec_dir + '/config/database.yml'))
-
+ActiveRecord::Base.configurations = YAML::load(ERB.new(File.read(spec_dir + '/config/database.yml')).result)
 ActiveRecord::Base.establish_connection :test
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Migration.create_table(:test_models, :force => true) {}


### PR DESCRIPTION
### Problem

Currently the test suite fails to run after a fresh clone and following the README instructions. 

### Solution

This changeset gets the test suite running again, and hopefully makes it more robust and future-proof by using docker-compose.

### Also

Fix the TravisCI build.