### PR TITLE
New configuration option to disable leader database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ Here's one way to accomplish that:
       end
     end
 
+## Disabling Leader
+
+To disable queries to the leader database -- for instance, in a production
+console -- set the disable_leader configuration to false. This will raise
+a ReplicaPools::LeaderDisabled error:
+
+  ReplicaPools.config.disable_leader = false
+
 ## Running specs
 
 Tests are run against MySQL 5.6 using docker-compose. 🐋

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require "bundler/gem_tasks"
 require "yaml"
-require 'rspec/core/rake_task'
-require "pp"
+require "rspec/core/rake_task"
 
 desc 'Default: run specs.'
 task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,15 @@
 require "bundler/gem_tasks"
-
+require "yaml"
 require 'rspec/core/rake_task'
+require "pp"
 
 desc 'Default: run specs.'
 task :default => :spec
 
 desc 'Bootstrap MySQL configuration'
 task :bootstrap do
-  puts "executing spec/config/bootstrap.sql\n\n"
-  system('mysql --verbose --user=root --host=127.0.0.1 --port=3309 mysql < spec/config/bootstrap.sql')
+  config = YAML::load(ERB.new(File.read('spec/config/database.yml')).result)["test"]
+  system("mysql --verbose --user=#{config["username"]} --host=#{config["host"]} --port=#{config["port"]} mysql < spec/config/bootstrap.sql")
 end
 
 desc "Run specs"

--- a/lib/replica_pools.rb
+++ b/lib/replica_pools.rb
@@ -11,6 +11,12 @@ require 'replica_pools/engine' if defined? Rails
 ActiveRecord::Base.send :include, ReplicaPools::ActiveRecordExtensions
 
 module ReplicaPools
+  class LeaderDisabled < StandardError
+    def to_s
+      "Leader database has been disabled. Re-enable with ReplicaPools.config.disable_leader = false."
+    end
+  end
+
   class << self
 
     def config
@@ -45,6 +51,7 @@ module ReplicaPools
     end
 
     def with_leader
+      raise LeaderDisabled.new if ReplicaPools.config.disable_leader
       proxy.with_leader{ yield }
     end
 

--- a/lib/replica_pools/active_record_extensions.rb
+++ b/lib/replica_pools/active_record_extensions.rb
@@ -5,7 +5,11 @@ module ReplicaPools
     end
 
     def reload(options = nil)
-      self.class.connection_proxy.with_leader { super }
+      if ReplicaPools.config.disable_leader
+        super
+      else
+        self.class.connection_proxy.with_leader { super }
+      end
     end
 
     module ClassMethods

--- a/lib/replica_pools/config.rb
+++ b/lib/replica_pools/config.rb
@@ -9,6 +9,10 @@ module ReplicaPools
     # Defaults to false.
     attr_accessor :defaults_to_leader
 
+    # When true, the leader database will not be selectable.
+    # Default to false.
+    attr_accessor :disable_leader
+
     # The list of methods considered safe to send to a readonly connection.
     # Defaults are based on Rails version.
     attr_accessor :safe_methods
@@ -16,6 +20,7 @@ module ReplicaPools
     def initialize
       @environment        = 'development'
       @defaults_to_leader = false
+      @disable_leader     = false
       @safe_methods       = []
     end
   end

--- a/lib/replica_pools/config.rb
+++ b/lib/replica_pools/config.rb
@@ -10,7 +10,7 @@ module ReplicaPools
     attr_accessor :defaults_to_leader
 
     # When true, the leader database will not be selectable.
-    # Default to false.
+    # Defaults to false.
     attr_accessor :disable_leader
 
     # The list of methods considered safe to send to a readonly connection.

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -108,6 +108,7 @@ module ReplicaPools
     end
 
     def route_to(conn, method, *args, &block)
+      raise ReplicaPools::LeaderDisabled.new if ReplicaPools.config.disable_leader && conn == leader
       conn.retrieve_connection.send(method, *args, &block)
     rescue => e
       ReplicaPools.log :error, "Error during ##{method}: #{e}"

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -55,6 +55,8 @@ module ReplicaPools
     end
 
     def with_leader
+      raise LeaderDisabled.new if ReplicaPools.config.disable_leader
+
       last_conn = self.current
       self.current = leader
       self.leader_depth += 1

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -122,7 +122,7 @@ module ReplicaPools
       ReplicaPools.log :error, "Current Connection: #{current}"
       ReplicaPools.log :error, "Current Pool Name: #{current_pool.name}"
       ReplicaPools.log :error, "Current Pool Members: #{current_pool.replicas}"
-      ReplicaPools.log :error, "leader Depth: #{leader_depth}"
+      ReplicaPools.log :error, "Leader Depth: #{leader_depth}"
     end
   end
 end

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -62,8 +62,10 @@ module ReplicaPools
       self.leader_depth += 1
       yield
     ensure
-      self.leader_depth = [leader_depth - 1, 0].max
-      self.current = last_conn
+      if last_conn
+        self.leader_depth = [leader_depth - 1, 0].max
+        self.current = last_conn
+      end
     end
 
     def transaction(*args, &block)

--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -26,7 +26,10 @@ module ReplicaPools
            :select_all, :select_one, :select_value, :select_values,
            :select_rows, :select, :select_prepared, :verify!, :raw_connection,
            :active?, :reconnect!, :disconnect!, :reset_runtime, :log,
-           :schema_cache, :lookup_cast_type_from_column, :clear_cache!, :sanitize_limit, :combine_bind_parameters
+           :lookup_cast_type_from_column, :sanitize_limit,
+           :combine_bind_parameters, :quote_table_name, :quote, :quote_column_names, :quote_table_names,
+           :case_sensitive_comparison, :case_insensitive_comparison,
+           :schema_cache, :cacheable_query, :prepared_statements, :clear_cache!
           ]
         else
           warn "Unsupported ActiveRecord version #{ActiveRecord.version}. Please whitelist the safe methods."

--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -25,7 +25,8 @@ module ReplicaPools
           [
            :select_all, :select_one, :select_value, :select_values,
            :select_rows, :select, :select_prepared, :verify!, :raw_connection,
-           :active?, :reconnect!, :disconnect!, :reset_runtime, :log
+           :active?, :reconnect!, :disconnect!, :reset_runtime, :log,
+           :schema_cache, :lookup_cast_type_from_column, :clear_cache!, :sanitize_limit, :combine_bind_parameters
           ]
         else
           warn "Unsupported ActiveRecord version #{ActiveRecord.version}. Please whitelist the safe methods."

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -157,7 +157,9 @@ describe ReplicaPools do
   end
 
   it 'should pre-generate safe methods' do
-    @proxy.should respond_to(:select_value)
+    ReplicaPools.config.safe_methods.each do |m|
+      @proxy.should respond_to(m)
+    end
   end
 
   it 'should dynamically generate unsafe methods' do

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -185,6 +185,20 @@ describe ReplicaPools do
     foo.reload
   end
 
+  context "with leader_disabled=true" do
+    after { ReplicaPools.config.disable_leader = false }
+
+    it 'should reload models from a replica' do
+      foo = TestModel.create!
+      ReplicaPools.config.disable_leader = true
+      foo = TestModel.last
+      @leader.should_not_receive(:select_all)
+      @default_replica1.should_receive(:select_all).and_return(ActiveRecord::Result.new(["id"], ["1"]))
+      @default_replica2.should_not_receive(:select_all)
+      foo.reload
+    end
+  end
+
   context "with_pool" do
 
     it "should switch to the named pool" do

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -137,6 +137,18 @@ describe ReplicaPools do
     end
   end
 
+  context "with leader_disabled=true" do
+    before { ReplicaPools.config.disable_leader = true }
+    after { ReplicaPools.config.disable_leader = false }
+    it 'should raise an error instead of sending dangerous methods to the leader' do
+      meths = [:insert, :update, :delete, :execute]
+      meths.each do |meth|
+        @default_replica1.stub(meth).and_raise(RuntimeError)
+        expect { @proxy.send(meth, @sql) }.to raise_error(ReplicaPools::LeaderDisabled)
+      end
+    end
+  end
+
   it "should not allow leader depth to get below 0" do
     @proxy.instance_variable_set("@leader_depth", -500)
     @proxy.instance_variable_get("@leader_depth").should == -500

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -54,6 +54,19 @@ describe ReplicaPools do
       end
       @proxy.send(:within_leader_block?).should_not be
     end
+
+    context "with leader_disabled=true" do
+      before { ReplicaPools.config.disable_leader = true }
+      after { ReplicaPools.config.disable_leader = false }
+
+      it 'should not execute query, and maintain replica connection' do
+        @executed = false
+        @proxy.current = @proxy.current_replica
+        expect { @proxy.with_leader { @executed = true } }.to raise_error(ReplicaPools::LeaderDisabled)
+        @executed.should eq(false)
+        @proxy.current.name.should eq('ReplicaPools::DefaultDb1')
+      end
+    end
   end
 
   context "transaction" do

--- a/spec/slave_pools_spec.rb
+++ b/spec/slave_pools_spec.rb
@@ -22,6 +22,16 @@ describe ReplicaPools do
     ReplicaPools.with_leader
   end
 
+  describe 'with leader disabled' do
+    before { ReplicaPools.config.disable_leader = true }
+    after { ReplicaPools.config.disable_leader = false }
+
+    it 'should delegate with_leader call to connection proxy' do
+      @proxy.should_receive(:with_leader).exactly(0)
+      expect { ReplicaPools.with_leader }.to raise_error(ReplicaPools::LeaderDisabled)
+    end
+  end
+
   it 'should delegate current call to connection proxy' do
     @proxy.should_receive(:current).exactly(1)
     ReplicaPools.current

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,4 +40,12 @@ end
 
 RSpec.configure do |c|
   c.include ReplicaPools::Testing
+
+  # This gem mostly uses the old deprecated shoulda syntax. Support both versions for now.
+  c.expect_with :rspec do |c|
+    c.syntax = [:expect, :should]
+  end
+  c.mock_with :rspec do |c|
+    c.syntax = [:expect, :should]
+  end
 end


### PR DESCRIPTION
This adds a new `ReplicaPools.config.disable_leader` option, which will disable access to the `leader` connection when set to `true`. When leader is disabled, the `with_leader` method will raise a `ReplicaPools::LeaderDisabled` error.

This could be useful when you want to force only readonly requests. For instance, you may want to do this in your Production Rails console:

``` ruby
# config/environments/production.rb
Kickstarter::Application.configure do
  console do
    ReplicaPools.config.disable_leader = true
  end
end
```