### PR TITLE
Add count to safe list of active record methods

### DIFF
--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -13,13 +13,13 @@ module ReplicaPools
           [
             :select_all, :select_one, :select_value, :select_values,
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
-            :disconnect!, :reset_runtime, :log, :log_info
+            :disconnect!, :reset_runtime, :log, :log_info, :count
           ]
         elsif ActiveRecord::VERSION::MAJOR == 4
           [
             :select_all, :select_one, :select_value, :select_values,
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
-            :disconnect!, :reset_runtime, :log
+            :disconnect!, :reset_runtime, :log, :count
           ]
         elsif ActiveRecord::VERSION::MAJOR == 5
           [
@@ -29,7 +29,7 @@ module ReplicaPools
            :lookup_cast_type_from_column, :sanitize_limit,
            :combine_bind_parameters, :quote_table_name, :quote, :quote_column_names, :quote_table_names,
            :case_sensitive_comparison, :case_insensitive_comparison,
-           :schema_cache, :cacheable_query, :prepared_statements, :clear_cache!
+           :schema_cache, :cacheable_query, :prepared_statements, :clear_cache!, :count
           ]
         else
           warn "Unsupported ActiveRecord version #{ActiveRecord.version}. Please whitelist the safe methods."

--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -13,13 +13,13 @@ module ReplicaPools
           [
             :select_all, :select_one, :select_value, :select_values,
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
-            :disconnect!, :reset_runtime, :log, :log_info, :count
+            :disconnect!, :reset_runtime, :log, :log_info
           ]
         elsif ActiveRecord::VERSION::MAJOR == 4
           [
             :select_all, :select_one, :select_value, :select_values,
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
-            :disconnect!, :reset_runtime, :log, :count
+            :disconnect!, :reset_runtime, :log
           ]
         elsif ActiveRecord::VERSION::MAJOR == 5
           [
@@ -29,7 +29,7 @@ module ReplicaPools
            :lookup_cast_type_from_column, :sanitize_limit,
            :combine_bind_parameters, :quote_table_name, :quote, :quote_column_names, :quote_table_names,
            :case_sensitive_comparison, :case_insensitive_comparison,
-           :schema_cache, :cacheable_query, :prepared_statements, :clear_cache!, :count
+           :schema_cache, :cacheable_query, :prepared_statements, :clear_cache!, :column_name_for_operation
           ]
         else
           warn "Unsupported ActiveRecord version #{ActiveRecord.version}. Please whitelist the safe methods."


### PR DESCRIPTION
# What

Adds `#count` to whitelisted active record's methods in read-only mode.

# Why

Because it was failing when I was running a `count` method on prod.

Reference: https://kickstarter.slack.com/archives/C0PNB94BU/p1545668674000100