### PR TITLE
Add table_alias_for to list of safe methods.

### DIFF
--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -27,7 +27,7 @@ module ReplicaPools
            :select_rows, :select, :select_prepared, :verify!, :raw_connection,
            :active?, :reconnect!, :disconnect!, :reset_runtime, :log,
            :lookup_cast_type_from_column, :sanitize_limit,
-           :combine_bind_parameters, :quote_table_name, :quote, :quote_column_names, :quote_table_names,
+           :combine_bind_parameters, :quote_table_name, :quote, :quote_column_names, :quote_table_names, :table_alias_for,
            :case_sensitive_comparison, :case_insensitive_comparison,
            :schema_cache, :cacheable_query, :prepared_statements, :clear_cache!, :column_name_for_operation
           ]


### PR DESCRIPTION
This adds the `table_alias_for` method to the list of safe methods to call on leader. 

Fixes this issue, when the leader is disabled:

```
» SomeModel.group(:some_column).count
[ReplicaPools] Error during #table_alias_for: Leader database has been disabled. Re-enable with ReplicaPools.config.disable_leader = false.
...
```

(similar to this issue: https://github.com/kickstarter/replica_pools/pull/23)