### PR TITLE
Rails 6 support

### DIFF
--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -21,7 +21,7 @@ module ReplicaPools
             :select_rows, :select, :verify!, :raw_connection, :active?, :reconnect!,
             :disconnect!, :reset_runtime, :log
           ]
-        elsif ActiveRecord::VERSION::MAJOR == 5
+        elsif [5, 6].include?(ActiveRecord::VERSION::MAJOR)
           [
            :select_all, :select_one, :select_value, :select_values,
            :select_rows, :select, :select_prepared, :verify!, :raw_connection,

--- a/lib/replica_pools/pools.rb
+++ b/lib/replica_pools/pools.rb
@@ -27,10 +27,20 @@ module ReplicaPools
 
     # finds valid pool configs
     def pool_configurations
-      ActiveRecord::Base.configurations.map do |name, config|
+      config_hash.map do |name, config|
         next unless name.to_s =~ /#{ReplicaPools.config.environment}_pool_(.*)_name_(.*)/
         [name, $1, $2]
       end.compact
+    end
+
+    def config_hash
+      if ActiveRecord::VERSION::MAJOR >= 6
+        # in Rails >= 6, `configurations` is an instance of ActiveRecord::DatabaseConfigurations
+        ActiveRecord::Base.configurations.to_h
+      else
+        # in Rails < 6, it's just a hash
+        ActiveRecord::Base.configurations
+      end
     end
 
     # generates a unique ActiveRecord::Base subclass for a single replica

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.1.3"
+  VERSION = "2.2.0.beta1"
 end


### PR DESCRIPTION
Seems like the only breaking change that affected us in Rails 6 was that [`ActiveRecord::Base.configurations` becomes an instance of `ActiveRecord::DatabaseConfigurations` instead of a plain hash](https://blog.bigbinary.com/2019/03/19/rails-6-changed-activerecord-base-configurations-result-to-an-object.html).

This also bumps our version to `2.2.0.beta1`.
