### PR TITLE
Rails 5.2 support for select_all

### DIFF
--- a/lib/replica_pools/query_cache.rb
+++ b/lib/replica_pools/query_cache.rb
@@ -24,6 +24,8 @@ module ReplicaPools
       # there may be more args for Rails 5.0+, but we only care about arel, name, and binds for caching.
       relation, name, raw_binds = args
 
+      # Rails 6.2 breaks this method as locked? is no longer available
+      # https://github.com/kickstarter/replica_pools/issues/26
       if !query_cache_enabled || locked?(relation)
         return route_to(current, :select_all, *args)
       end
@@ -32,7 +34,7 @@ module ReplicaPools
       if raw_binds.blank? && relation.is_a?(ActiveRecord::Relation)
         arel, binds = relation.arel, relation.bind_values
       else
-        arel, binds = relation, raw_binds
+        arel, binds = relation, raw_binds.to_a
       end
 
       sql = to_sql(arel, binds)

--- a/lib/replica_pools/query_cache.rb
+++ b/lib/replica_pools/query_cache.rb
@@ -34,7 +34,7 @@ module ReplicaPools
       if raw_binds.blank? && relation.is_a?(ActiveRecord::Relation)
         arel, binds = relation.arel, relation.bind_values
       else
-        arel, binds = relation, raw_binds.to_a
+        arel, binds = relation, Array(raw_binds)
       end
 
       sql = to_sql(arel, binds)

--- a/replica_pools.gemspec
+++ b/replica_pools.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec')
   s.add_development_dependency('rake')
   s.add_development_dependency('rails')
+  s.add_development_dependency('pry')
 end

--- a/spec/query_cache_spec.rb
+++ b/spec/query_cache_spec.rb
@@ -1,5 +1,6 @@
 require 'rack'
 require_relative 'spec_helper'
+require_relative 'config/test_model'
 
 describe ReplicaPools::QueryCache do
   before(:each) do
@@ -101,6 +102,18 @@ describe ReplicaPools::QueryCache do
       it 'should invalidate the cache on insert, delete and update' do
         executor.wrap { insert_update_delete_lambda }
       end
+    end
+  end
+
+  describe '.pluck regression test' do
+    it 'should work with query caching' do
+      TestModel.connection.enable_query_cache!
+      expect(TestModel.pluck(:id).count).to eql TestModel.all.count
+    end
+
+    it 'should work if query cache is not enabled' do
+      TestModel.connection.disable_query_cache!
+      expect(TestModel.pluck(:id).count).to eql TestModel.all.count
     end
   end
 end


### PR DESCRIPTION
## What

This is a fix to support Rails 5.2. 
Replica pools fails on app boot because we're passing in `nil` for binds and in the new version, we're calling `empty?` on nil. This throws an error. 

Failing here in rails 5.2: https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L19

## How

- The error is fixed by coercing the nil value to an array before passing it to `to_sql`
- Also added a comment/link to issue regarding rails edge where the `locked?` method is no longer available.


