### PR TITLE
fix(pools): make config hash backwards compatible with rails 6

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -10,7 +10,7 @@ jobs:
           - "2.7"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Start MySQL

--- a/lib/replica_pools/pools.rb
+++ b/lib/replica_pools/pools.rb
@@ -34,11 +34,14 @@ module ReplicaPools
     end
 
     def config_hash
-      if ActiveRecord::VERSION::MAJOR >= 6
-        # in Rails >= 6, `configurations` is an instance of ActiveRecord::DatabaseConfigurations
+      if ActiveRecord::VERSION::MAJOR > 6
+        # in Rails = 7, ActiveRecord::Base.configurations.to_h has been deprecated
         ActiveRecord::Base.configurations.configs_for.map do |c|
           [c.env_name, c.configuration_hash.transform_keys(&:to_s)]
         end.to_h
+      elsif ActiveRecord::VERSION::MAJOR == 6
+        # in Rails = 6, `configurations` is an instance of ActiveRecord::DatabaseConfigurations
+        ActiveRecord::Base.configurations.to_h
       else
         # in Rails < 6, it's just a hash
         ActiveRecord::Base.configurations

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
A recent [patch](https://github.com/kickstarter/replica_pools/commit/0f1a8bec22484274ad8026b9b7a54190163bb0ff#diff-721020bd01f6934dada030c7b496c4b80781881038f10d8561feaa6b39362d32R40) to support a rails 7 upgrade made it incompatible with active record v 6.

```
NoMethodError: undefined method `configuration_hash' for #<ActiveRecord::DatabaseConfigurations::HashConfig:0x000055b2a02c8cf8>
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.0/lib/replica_pools/pools.rb:40:in `block in config_hash'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.0/lib/replica_pools/pools.rb:39:in `map'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.0/lib/replica_pools/pools.rb:39:in `config_hash'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.0/lib/replica_pools/pools.rb:30:in `pool_configurations'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.0/lib/replica_pools/pools.rb:9:in `initialize
```

This updates the condition to check if the version of active record is version 7 before using the `configuration_hash` https://api.rubyonrails.org/classes/ActiveRecord/DatabaseConfigurations/HashConfig.html 

I added a new conditional in the if block so it's replica pools is backwards compatible. 