### PR TITLE
fix(connection-proxy): make config backwards compatible with rails ver < 7

### DIFF
--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -33,7 +33,11 @@ module ReplicaPools
       # this ivar is for ConnectionAdapter compatibility
       # some gems (e.g. newrelic_rpm) will actually use
       # instance_variable_get(:@config) to find it.
-      @config = current.connection_db_config
+      if ActiveRecord::VERSION::MAJOR >= 7
+        @config = current.connection_db_config
+      else
+        @config = current.connection_config
+      end
     end
 
     def with_pool(pool_name = 'default')

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.4.1"
+  VERSION = "2.4.2"
 end


### PR DESCRIPTION
A recent patch that was made to support a rails 7 upgrade made it incompatible with active record v 6.

```
NoMethodError: undefined method `connection_db_config' for ActiveRecord::Base:Class
Did you mean?  connection_config
/root/project/vendor/bundle/ruby/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.1/lib/replica_pools/connection_proxy.rb:36:in `initialize'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.1/lib/replica_pools.rb:37:in `new'
/root/project/vendor/bundle/ruby/2.7.0/gems/replica_pools-2.4.1/lib/replica_pools.rb:37:in `proxy'
```

This adds a condition to check if the version of active record is version 7 before using `connection_db_config`
