### PR TITLE
Send keyword args with ** for Ruby 3.0

### DIFF
--- a/lib/replica_pools/active_record_extensions.rb
+++ b/lib/replica_pools/active_record_extensions.rb
@@ -20,7 +20,7 @@ module ReplicaPools
       # Make sure transactions run on leader
       # Even if they're initiated from ActiveRecord::Base
       # (which doesn't have our hijack).
-      def transaction(options = {}, &block)
+      def transaction(**options, &block)
         if self.connection.kind_of?(ConnectionProxy)
           super
         else

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -101,9 +101,9 @@ module ReplicaPools
       leader_depth > 0
     end
 
-    def route_to(conn, method, *args, &block)
+    def route_to(conn, method, *args, **keyword_args, &block)
       raise ReplicaPools::LeaderDisabled.new if ReplicaPools.config.disable_leader && conn == leader
-      conn.retrieve_connection.send(method, *args, &block)
+      conn.retrieve_connection.send(method, *args, **keyword_args, &block)
     rescue => e
       ReplicaPools.log :error, "Error during ##{method}: #{e}"
       log_proxy_state


### PR DESCRIPTION
Ruby 3.0 is more strict about keyword arguments. They now can no longer be passed as a Hash. Because of this, positional arguments and keyword arguments need to be treated differently. In this case, `args` is an array of 3 positional arguments and a Hash of keyword arguments. We need to single splat the positional arguments and double splat the keyword arguments.