### PR TITLE
Ruby 3.0 upgrades to keyword arguments

### DIFF
--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -64,8 +64,8 @@ module ReplicaPools
       end
     end
 
-    def transaction(*args, &block)
-      with_leader { leader.transaction(*args, &block) }
+    def transaction(...)
+      with_leader { leader.transaction(...) }
     end
 
     def next_replica!
@@ -86,9 +86,9 @@ module ReplicaPools
     # Proxies any unknown methods to leader.
     # Safe methods have been generated during `setup!`.
     # Creates a method to speed up subsequent calls.
-    def method_missing(method, *args, &block)
-      self.class.define_method(method) do |*args, &block|
-        route_to(leader, method, *args, &block).tap do
+    def method_missing(method, *args, **kwargs, &block)
+      self.class.define_method(method) do |*args, **kwargs, &block|
+        route_to(leader, method, *args, **kwargs, &block).tap do
           if %i[insert delete update].include?(method)
             leader.retrieve_connection.clear_query_cache
           end

--- a/lib/replica_pools/query_cache.rb
+++ b/lib/replica_pools/query_cache.rb
@@ -18,11 +18,11 @@ module ReplicaPools
     # select_all is trickier. it needs to use the leader
     # connection for cache logic, but ultimately pass its query
     # through to whatever connection is current.
-    def select_all(*args)
+    def select_all(*args, **kwargs)
       relation, name, raw_binds = args
 
       if !query_cache_enabled || locked?(relation)
-        return route_to(current, :select_all, *args)
+        return route_to(current, :select_all, *args, **kwargs)
       end
 
       # duplicate binds_from_relation behavior introduced in 4.2.
@@ -38,9 +38,9 @@ module ReplicaPools
       args[2] = binds
 
       if Gem::Version.new(ActiveRecord.version) < Gem::Version.new('5.1')
-        cache_sql(sql, binds) { route_to(current, :select_all, *args) }
+        cache_sql(sql, binds) { route_to(current, :select_all, *args, **kwargs) }
       else
-        cache_sql(sql, name, binds) { route_to(current, :select_all, *args) }
+        cache_sql(sql, name, binds) { route_to(current, :select_all, *args, **kwargs) }
       end
     end
 

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.5.0"
+  VERSION = "2.6.0"
 end

--- a/replica_pools.gemspec
+++ b/replica_pools.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.1}
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_dependency('activerecord', ["> 6.0", "< 8.0"])
   s.add_development_dependency('mysql2', ["~> 0.5"])


### PR DESCRIPTION
updating some method signatures to support the new keyword argument separation. 

I utilized the new argument forwarding syntax since this is designed around supporting ruby 3.0 we should be fine to make use of ruby 3 features.