### PR TITLE
Make ReplicaPools compatible with Rails 6 and 7

### DIFF
--- a/lib/replica_pools/pools.rb
+++ b/lib/replica_pools/pools.rb
@@ -57,7 +57,11 @@ module ReplicaPools
       ReplicaPools.const_set(class_name, Class.new(ActiveRecord::Base) do |c|
         c.abstract_class = true
         c.define_singleton_method(connection_config_method_name) do
-          configurations.configs_for(env_name: connection_name.to_s, include_hidden: true)
+          if ActiveRecord::VERSION::MAJOR == 6
+            configurations.configs_for(env_name: connection_name.to_s, include_replicas: true)
+          elsif ActiveRecord::VERSION::MAJOR == 7
+            configurations.configs_for(env_name: connection_name.to_s, include_hidden: true)
+          end
         end
       end)
 

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.6.2"
+  VERSION = "2.6.3"
 end


### PR DESCRIPTION
The ActiveRecord `configs_for` method takes a `include_hidden` argument on Rails 7 to include replicas in its results, but on Rails 6 this argument doesn't exist and instead `include_replicas` is the argument name.