### PR TITLE
[INF-1684] uses the connection pool to ensure a connection isnt shared cross thr…

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,8 +2,8 @@ version: "2.0"
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     ports:
-      - 127.0.0.1:3309:3306
+      - 3309:3306
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"

--- a/lib/replica_pools/engine.rb
+++ b/lib/replica_pools/engine.rb
@@ -50,6 +50,7 @@ module ReplicaPools
            case_sensitive_comparison
            clear_cache!
            column_name_for_operation
+           column_name_matcher
            column_name_with_order_matcher
            combine_bind_parameters
            disconnect!

--- a/lib/replica_pools/pools.rb
+++ b/lib/replica_pools/pools.rb
@@ -64,10 +64,6 @@ module ReplicaPools
           end
         end
       end)
-
-      ReplicaPools.const_get(class_name).tap do |c|
-        c.establish_connection(connection_name.to_sym)
-      end
     end
 
   end

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.6.3"
+  VERSION = "2.7.3"
 end

--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.7.3"
+  VERSION = "2.7.0"
 end

--- a/spec/config/bootstrap.sql
+++ b/spec/config/bootstrap.sql
@@ -1,3 +1,4 @@
 -- Create MySQL db & user for running specs
-create database IF NOT EXISTS test_db;
-grant select on test_db.* to 'read_only' identified by 'readme';
+CREATE DATABASE IF NOT EXISTS test_db;
+CREATE USER 'read_only'@'%' IDENTIFIED BY 'readme';
+GRANT SELECT ON test_db.* TO 'read_only'@'%';

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -7,6 +7,7 @@ test: &test
   encoding: utf8
   read_timeout: 1
   database: test_db
+  pool: 10 # pool needs to be large enough to create a connection for each pool simultaneously
 
 readonly_login: &readonly_login
   <<: *test

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -6,11 +6,30 @@ describe ReplicaPools do
   before(:each) do
     @sql = 'SELECT NOW()'
 
+    # here we save the real connection pool and checkout a connection from it
+    # this lets us verify calls to specific connections in the specs then check back in
+    # those connections once each test block is done
     @proxy = ReplicaPools.proxy
-    @leader = @proxy.leader.retrieve_connection
+    @leader_connection_pool = @proxy.leader.connection_pool
+    @leader = @leader_connection_pool.checkout
+
+    # need to checkout the replica connections before connection_pool is mocked since the
+    # the same pool object is used for leader and replicas since they have the same connection config
+    create_replica_aliases(@proxy)
+
+    # we now mock out the connection pool so it doesn't checkout new connections mid spec run
+    # instead we pass our already checked out connection in each test
+    leader_connection_pool = instance_double("ActiveRecord::ConnectionPool")
+    allow(@proxy.leader).to receive(:connection_pool).and_return(leader_connection_pool)
+    allow(leader_connection_pool).to receive(:checkout).and_return(@leader)
+    allow(leader_connection_pool).to receive(:checkin)
 
     reset_proxy(@proxy)
-    create_replica_aliases(@proxy)
+  end
+
+  after(:each) do
+    @leader_connection_pool.checkin(@leader)
+    close_replica_aliases(@proxy)
   end
 
   it 'AR::B should respond to #connection_proxy' do
@@ -129,7 +148,9 @@ describe ReplicaPools do
   end
 
   it 'should send dangerous methods to the leader' do
-    meths = [:insert, :update, :delete, :execute]
+    meths = [:insert, :update, :delete]
+    @leader.should_receive(:clear_query_cache).exactly(4) # it is called one extra time internally
+
     meths.each do |meth|
       @default_replica1.stub(meth).and_raise(RuntimeError)
       @leader.should_receive(meth).and_return(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'logger'
-require 'pry'
 
 module Rails
   def self.env


### PR DESCRIPTION
…ead; also allows dead connections to be reformed

# Connection error theory
We don't see connections sit inside rds for longer than 180s, but they aren't being killed just recycled. Watching the processlist there you can see when a connection reaches TIME=180 it reappears at the bottom of the list with TIME=0. This is probably the RDS proxy trying to keep them fresh. However, we do see in the RDS error running logs frequent aborted connections. It could be that these connections are getting refreshed mid request leading to some wonkyness, which leads to RDS aborting them.

# Replicating this behaviour
## Happyish path
1. SSH into an instance twice, 2 sessions will make it easy to see how things are working
2. In once session edit the MYSQL_DATABASE_HOST to connect directly to the writer instance (testing through the proxy is difficult because the process list shows connections from the proxy not the instances)
3. Start a rails console
4. In the other SSH session run `ps aux | grep ruby` to get the pid of the console process. Then run `watch -n 2 "ss -p | grep the_console_pid"` this will constantly monitor network connections to your console
5. In the console run this block 
```ruby
ReplicaPools.with_leader do
    User.last
end
```
You should see a mysql connection start in the other SSH watch window and this query resolve successfully.
6. In your DB client of choice connect to the writer instance. Run this query with the IP for the instance you're on. (Should be in the ss watch window too)
```sql
select * from information_schema.processlist where HOST like '172.24.15.59%' order by TIME desc;
```
This should show your connection, match the port here with that of the SSH watch window to confirm
7. From the sql output you can now force kill your connection. `kill id_from_prev_query`
8. Notice in your SSH watch window that the connection changes from `ESTAB` to `CLOSE_WAIT`. This is consistent with the production issue of connections getting dropped. It means that the Mysql server has closed the connection but your local process hasn't acknowledged it yet.
9. Rerun this query block
```ruby
ReplicaPools.with_leader do
    User.last
end
```
It will now fail saying the connection was disconnected mid request. Also the connection will now be gone from the SSH watch window. Run it again and the error will change to Mysql not connected, makes sense since you don't see a connection in the watch window anymore.

# How does this PR fix things
Using the `retrieve_connection` method defined [here](https://github.com/rails/rails/blob/7c03e4f1b7553084f34318a9efc2793137de36f4/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb#L231) will just get _a_ connection from the connection_pool. However, when the connection is dropped, the connection object in the connection_pool isn't aware of it. It still thinks there is a valid connection so it'll be returned when retrieved but then fail to actually work, since it's no long valid. I'm guessing the `reconnect: true` that was set in our database.yml would fix this up periodically to keep it valid.
With this PR we instead checkout connections from the connection_pool as intended or create new ones as needed up to 5. This allows us to actually use the pool of connections across threads and ensures the connection we get is valid. 
In rerunning the above replication steps we see 2 connections get made to the DB when the query block is run (not sure why the extra connection at this point). However if we kill both threads processes in RDS then rerun our query, the conneciton_pool gracefully provisions a working connection for us to use and succeeds.