### PR TITLE
pass through `**kwargs` in method missing

### DIFF
--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -100,7 +100,7 @@ module ReplicaPools
           end
         end
       end
-      send(method, *args, &block)
+      send(method, *args, **kwargs, &block)
     end
 
     def within_leader_block?


### PR DESCRIPTION
# What

This PR fixes a bug - we are not passing in `**kwargs` from `method_missing` down to the newly-defined method.  This has likely gone unnoticed because Rails wasn't using any keyword arguments with any methods on this class - as of Rails 7.1, it is using keyword arguments (namely, [`returning:`](https://github.com/rails/rails/blame/6b93fff8af32ef5e91f4ec3cfffb081d0553faf0/activerecord/lib/active_record/persistence.rb#L590)).

# Why

This fix allows this CI step to pass for https://github.com/kickstarter/kickstarter/pull/25906

<img width="1429" alt="Screenshot 2024-01-08 at 11 00 33 AM" src="https://github.com/kickstarter/replica_pools/assets/9829542/78c00d19-1bf9-4780-a4fa-3f5baa89c4ac">
