### PR TITLE
bump version to 2.6.5

### DIFF
--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.6.3"
+  VERSION = "2.6.5"
 end


### PR DESCRIPTION
Bumping the version to 2.6.5 so I can release onto rubygems.  This release functionally only contains this change: #47

Version 2.6.4 has already been released even though the version change was reverted in #46, so I'm releasing at 2.6.5.