### PR TITLE
fix release action

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -42,8 +42,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: kickstarter/actions/setup-rubygems@main
-        with:
-          api-key: ${{ secrets.RUBYGEMS_API_KEY }}
+      # The kickstarter/actions/setup-rubygems action is not available
+      # because this is a public repo
+      - run: |
+          mkdir -p ~/.gem
+          cat <<-YAML > ~/.gem/credentials
+          ---
+          :rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
+          YAML
+          chmod 0600 ~/.gem/credentials
       - run: bundle install
       - run: bundle exec rake gem:push

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,6 +39,14 @@ tasks:
       - bundle exec rake spec
 
   release:
+    desc: Publish gem with GitHub
+    vars:
+      VERSION:
+        sh: bundle exec ruby -r replica_pools -e 'puts "v#{ReplicaPools::VERSION}"'
+    cmds:
+      - gh release create {{.VERSION}} --generate-notes
+
+  release:manual:
     desc: Release gem
     cmds:
       - bundle exec rake release


### PR DESCRIPTION
private actions aren't available on public repos
make ksr release use GitHub actions
move old release to release:manual