### PR TITLE
Update `select_all` for Rails 7.1

### DIFF
--- a/spec/query_cache_spec.rb
+++ b/spec/query_cache_spec.rb
@@ -116,4 +116,16 @@ describe ReplicaPools::QueryCache do
       expect(TestModel.pluck(:id).count).to eql TestModel.all.count
     end
   end
+
+  describe '.ids regression test' do
+    it 'should work with query caching' do
+      TestModel.connection.enable_query_cache!
+      expect(TestModel.ids.count).to eql TestModel.all.count
+    end
+
+    it 'should work if query cache is not enabled' do
+      TestModel.connection.disable_query_cache!
+      expect(TestModel.ids.count).to eql TestModel.all.count
+    end
+  end
 end


### PR DESCRIPTION
In order to update to Rails 7.1, we need to accomodate the changes in https://github.com/rails/rails/commit/213796fb4936dce1da2f0c097a054e1af5c25c2c, which was released as part of Rails 5.2.

Many of the methods that were being used here either no longer exist or have different signatures.  I think its just coincidence that we haven't seen errors with this yet.

Here's the method we're imitating in 7.0.8:
https://github.com/rails/rails/blob/fc734f28e65ef8829a1a939ee6702c1f349a1d5a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L96-L112

# See

~~https://adhoc2.dev.kickstarter.com/~~ adhoc2 [is now being used for something else](https://kickstarter.slack.com/archives/C030WBQRU/p1704833408412399), but if you'd like to try it out yourself feel free to deploy https://github.com/kickstarter/kickstarter/pull/25976 to an adhoc env!

With these changes, Kickstarter CI passes:
7.0.8 (https://github.com/kickstarter/kickstarter/pull/25976): https://app.circleci.com/pipelines/github/kickstarter/kickstarter/58295/workflows/875aa7ce-9968-4735-ab4f-ad78b9c66084