### PR TITLE
[INF-1923] add check for already defined constant

### DIFF
--- a/lib/replica_pools/version.rb
+++ b/lib/replica_pools/version.rb
@@ -1,3 +1,3 @@
 module ReplicaPools
-  VERSION = "2.6.6"
+  VERSION = "2.6.7"
 end


### PR DESCRIPTION
This change adds a check for whether or not `ReplicaPools(class_name)` is already defined before setting it again to mitigate warning messages in the sidekiq stderr logs:

```
warning: already initialized constant ReplicaPools::Admin1
```

Also bumps the minor release version to `2.6.7`.