### PR TITLE
Support `ActiveRecord` 7.2

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -23,6 +23,10 @@ jobs:
           - "2.7"
           - "3.1"
           - "3.2"
+          - "3.3"
+        activerecord:
+          - "7.1"
+          - "7.2"
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
@@ -42,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
       # The kickstarter/actions/setup-rubygems action is not available
       # because this is a public repo
       - name: setup-rubygems
@@ -53,5 +57,5 @@ jobs:
           :rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
           YAML
           chmod 0600 ~/.gem/credentials
-      - run: bundle install
+      - run: ACTIVE_RECORD_VERSION=${{ matrix.activerecord }} bundle install
       - run: bundle exec rake release

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,16 @@
 source "https://rubygems.org"
 gemspec
+
+group :development do
+  # This allows us to easily switch between different versions of ActiveRecord.
+  # To use this in local dev, you can do:
+  # ```
+  # rm Gemfile.lock
+  # ACTIVE_RECORD_VERSION="7.1" bundle install
+  # ```
+  active_record_version = ENV.fetch("ACTIVE_RECORD_VERSION", nil)
+  gem "activerecord", "~> #{active_record_version}.0" if active_record_version&.length&.positive?
+
+  # Just helping out the bundler resolver:
+  gem "rails", "> 6.0"
+end

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,7 @@ dotenv:
   - .env
 
 vars:
-  RUBY_VERSION: 3.2.2
+  RUBY_VERSION: 3.3.5
 
 tasks:
   init:

--- a/lib/replica_pools/active_record_extensions.rb
+++ b/lib/replica_pools/active_record_extensions.rb
@@ -17,6 +17,10 @@ module ReplicaPools
         ReplicaPools.proxy
       end
 
+      def with_connection_proxy
+        yield ReplicaPools.proxy
+      end
+
       # Make sure transactions run on leader
       # Even if they're initiated from ActiveRecord::Base
       # (which doesn't have our hijack).

--- a/lib/replica_pools/hijack.rb
+++ b/lib/replica_pools/hijack.rb
@@ -18,6 +18,7 @@ module ReplicaPools
     def hijack_connection
       class << self
         alias_method :connection, :connection_proxy
+        alias_method :with_connection, :with_connection_proxy
       end
     end
   end

--- a/spec/query_cache_spec.rb
+++ b/spec/query_cache_spec.rb
@@ -22,7 +22,7 @@ describe ReplicaPools::QueryCache do
       @default_replica2.should_not_receive(:select_all)
       @leader.should_not_receive(:select_all)
       3.times { @proxy.select_all(@sql) }
-      @leader.query_cache.keys.size.should == 1
+      @leader.query_cache.size.should == 1
     end
   end
 
@@ -38,9 +38,9 @@ describe ReplicaPools::QueryCache do
       5.times do |i|
         @proxy.select_all(@sql)
         @proxy.select_all(@sql)
-        @leader.query_cache.keys.size.should == 1
+        @leader.query_cache.size.should == 1
         @proxy.send(meths[i], '')
-        @leader.query_cache.keys.size.should == 0
+        @leader.query_cache.size.should == 0
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,4 +50,7 @@ RSpec.configure do |c|
   c.mock_with :rspec do |c|
     c.syntax = [:expect, :should]
   end
+
+  c.filter_run focus: true
+  c.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
1. Add Ruby 3.3 to CI
2. Set up CI to test multiple versions of `ActiveRecord`.  Test 7.1 and 7.2.
3. Configure RSpec to use `:focus` metadata for ease of testing.
4. Update QueryCache tests for 7.2.  We need to accomodate the changes in this commit: https://github.com/rails/rails/commit/85742ce529b028812066cd6070e7de2ff3d44bc8
    `#query_cache` used to return a `Hash`, but it now returns a custom class. Fortunately, both `Hash` and [this custom class](https://github.com/rails/rails/commit/85742ce529b028812066cd6070e7de2ff3d44bc8#diff-0864dd3568afeffa8fde1c1dbeb48219e24854070f24bfaa913d00cd6c7343ebR46-R48) implement a `#size` method which works the same as doing `keys.size`.
5.  Add `with_connection_proxy` method.  `ActiveRecord::Base` now has the `with_connection` method, which is like the old `connection` method on `ActiveRecord::Base` but it yields the connection to a block instead of returning it: https://github.com/rails/rails/commit/22f41a1b40eb3ff5b94c8db4495ec5c93b513685
    This new method is now used for transactions, so in order for transactions to work we need to implement an equivalent in Replica Pools.